### PR TITLE
remove tracker reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 ![Build Status](https://travis-ci.org/IBM/sms-analysis-with-wks.svg?branch=master)
 
-<!--
-![Bluemix Deployments](https://deployment-tracker.mybluemix.net/stats/2beb5ac0f2b130c628328825c48f65c5/badge.svg)
--->
-
 This code pattern describes how to analyze SMS messages with Watson Knowledge Studio (WKS) and Watson's Natural Language Understanding (NLU) capability to extract entities in the data. Current natural language processing techniques cannot extract or interpret data that is domain or industry specific. The data (entities) represent different meaning in different domains. The best answer to such a problem is IBM's Watson Knowledge Studio. Consider a case where we need to extract entities present in a commercial SMS. For example:
 
 ```


### PR DESCRIPTION
the README contained the only reference to the tracker, the pom.xml file didn't actually use the tracker that the sample java metrics code mentions: https://github.com/Tomcli/local-liberty-tutorial/blob/master/pom.xml#L19-L23

Related-Bug: #25