### PR TITLE
changes for IAM_APIKEY credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,12 @@ From the **Access & Tools -> Documents** panel, press the **Create Annotation Se
 
 ## 7. Create a Task for Human Annotation
 
+> Note: With the latest release of Watson Knowledge Studio, most of the remainig steps below reference menu actions that have been moved. There is a new **Machine Learning Model** menu item that has been added to the left side of the UI panel. It contains actions associated with **Tasks** (now referred to as **Annotation Tasks**), **Performance**, and **Versions**. Please keep this in mind as you navigate the following steps.
+
 Add a task for human annotation by creating a task and assigning it annotation sets.
 
 From the **Access & Tools -> Documents** panel, select the **Task** tab and press the **Add Task** button.
+
 
 ![](doc/source/images/wks/task-2-create_task.png)
 
@@ -405,7 +408,7 @@ To download and install maven, refer to [maven.](https://maven.apache.org/downlo
 
 #### Add NLU Credentials and WKS Model ID to config.properties file
 
-The config.properties file is located in the `src/main/resources` directory. Replace the default values with the appropriate credentials (either IAM apikey, or username/password) and model ID values (quotes are not required).
+The config.properties file is located in the `src/main/resources` directory. Replace the default values with the appropriate credentials (either API key, or username/password) and model ID values (quotes are not required).
 
 ```
 # Watson Natural Language Understanding

--- a/README.md
+++ b/README.md
@@ -405,12 +405,18 @@ To download and install maven, refer to [maven.](https://maven.apache.org/downlo
 
 #### Add NLU Credentials and WKS Model ID to config.properties file
 
-The config.properties file is located in the `src/main/resources` directory. Replace the default values with the appropriate credentials and model ID values (quotes are not required).
+The config.properties file is located in the `src/main/resources` directory. Replace the default values with the appropriate credentials (either IAM apikey, or username/password) and model ID values (quotes are not required).
 
 ```
-NATURAL_LANGUAGE_UNDERSTANDING_USERNAME = <add_nlu_username>
-NATURAL_LANGUAGE_UNDERSTANDING_PASSWORD = <add_nlu_password>
-WATSON_KNOWLEDGE_STUDIO_MODEL_ID = <add_model_id>
+# Watson Natural Language Understanding
+NATURAL_LANGUAGE_UNDERSTANDING_URL=https://gateway.watsonplatform.net/natural-language-understanding/api
+## Un-comment and use either username+password or IAM apikey.
+NATURAL_LANGUAGE_UNDERSTANDING_IAM_APIKEY=<add_nlu_iam_apikey>
+#NATURAL_LANGUAGE_UNDERSTANDING_USERNAME=<add_nlu_username>
+#NATURAL_LANGUAGE_UNDERSTANDING_PASSWORD=<add_nlu_password>
+
+# Watson Knowledge Studio Model ID
+WATSON_KNOWLEDGE_STUDIO_MODEL_ID=<add_model_id>
 ```
 
 #### Build and Run

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ applications:
   memory: 256M
   path: target/NLUApp.war
   disk_quota: 1024M
-  random-route: true
+  random-route: false
   buildpack: liberty-for-java
   services:
   - sms_nlu_service

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
 		</developer>
 	</developers>
 	<scm>
-		<connection>scm:git:git@github.com/ragudiko/wks-nlu-sms-analysis.git</connection>
-		<developerConnection>scm:git:git@github.com/ragudiko/wks-nlu-sms-analysis.git</developerConnection>
-		<url>git@github.com/ragudiko/wks-nlu-sms-analysis.git</url>
+		<connection>scm:git:git@github.com/IBM/sms-analysis-with-wks.git</connection>
+		<developerConnection>scm:git:git@github.com/IBM/sms-analysis-with-wks.git</developerConnection>
+		<url>git@github.com/IBM/sms-analysis-with-wks.git</url>
 	</scm>
 
 <distributionManagement>
@@ -151,8 +151,8 @@
   	<dependency>
   		<groupId>com.ibm.watson.developer_cloud</groupId>
   		<artifactId>java-sdk</artifactId>
-  		<version>3.8.0</version>
-  	</dependency>
+			<version>6.2.0</version>
+		</dependency>
   	<dependency>
   		<groupId>junit</groupId>
   		<artifactId>junit</artifactId>

--- a/src/main/java/com/ibm/watson/nlu/DemoServlet.java
+++ b/src/main/java/com/ibm/watson/nlu/DemoServlet.java
@@ -198,7 +198,7 @@ public class DemoServlet extends HttpServlet {
 				apikey = (String) credentials.get("apikey");
 				username = (String) credentials.get("username");
 				password = (String) credentials.get("password");
-				if (apikey == null || apikey.isEmpty())) {
+				if (apikey == null || apikey.isEmpty()) {
 					useIamApiKey = false;
 				}
 				logger.info("baseURL  = " + baseURL);

--- a/src/main/java/com/ibm/watson/nlu/DemoServlet.java
+++ b/src/main/java/com/ibm/watson/nlu/DemoServlet.java
@@ -171,7 +171,7 @@ public class DemoServlet extends HttpServlet {
 			useIamApiKey = false;
 		}
 
-		logger.info("using IAM_APIKEY = " + useIamApiKey);
+		logger.info("using apikey = " + useIamApiKey);
 
 		return true;
 	}
@@ -205,7 +205,7 @@ public class DemoServlet extends HttpServlet {
 				logger.info("apikey = " + apikey);
 				logger.info("username = " + username);
 				logger.info("password = " + password);
-				logger.info("using IAM_APIKEY = " + useIamApiKey);
+				logger.info("using apikey = " + useIamApiKey);
 			} else {
 				logger.info("Doesn't match /^" + serviceName + "/");
 			}

--- a/src/main/java/com/ibm/watson/nlu/SimpleNLUClient.java
+++ b/src/main/java/com/ibm/watson/nlu/SimpleNLUClient.java
@@ -11,6 +11,7 @@ import com.ibm.watson.developer_cloud.natural_language_understanding.v1.model.En
 import com.ibm.watson.developer_cloud.natural_language_understanding.v1.model.Features;
 import com.ibm.watson.developer_cloud.natural_language_understanding.v1.model.ListModelsResults;
 import com.ibm.watson.developer_cloud.natural_language_understanding.v1.model.AnalyzeOptions.Builder;
+import com.ibm.watson.developer_cloud.service.security.IamOptions;
 
 public class SimpleNLUClient {
 
@@ -18,21 +19,30 @@ public class SimpleNLUClient {
 	private int maxResponses = Integer.MAX_VALUE;  // maximum # of responses to return, default value
 
 
-	public void initService(String userName,String password, String optionalURL){
+	public void initService(String userName, String password, String optionalURL){
 		service = null;
 		if(optionalURL !="")
 		{
-				service= new NaturalLanguageUnderstanding( NaturalLanguageUnderstanding.VERSION_DATE_2017_02_27);
+				service= new NaturalLanguageUnderstanding("2018-03-16");
 				service.setApiKey("");
 				service.setEndPoint(optionalURL);
 		}
 		else
 		{
-			service= new NaturalLanguageUnderstanding( NaturalLanguageUnderstanding.VERSION_DATE_2017_02_27,userName,password);
+			service= new NaturalLanguageUnderstanding("2018-03-16", userName, password);
 		}
 
 	}
 
+	public void initIamService(String apikey, String url){
+		service = null;
+		IamOptions options = new IamOptions.Builder()
+			.apiKey(apikey)
+			.build();
+
+		service= new NaturalLanguageUnderstanding("2018-03-16", options);
+		service.setEndPoint(url);
+	}
 
 	public SimpleNLUClient(){
 

--- a/src/main/java/com/ibm/watson/nlu/SimpleNLUClient.java
+++ b/src/main/java/com/ibm/watson/nlu/SimpleNLUClient.java
@@ -17,19 +17,20 @@ public class SimpleNLUClient {
 
 	private NaturalLanguageUnderstanding service;
 	private int maxResponses = Integer.MAX_VALUE;  // maximum # of responses to return, default value
+	private String versionDate = "2018-03-16";
 
 
 	public void initService(String userName, String password, String optionalURL){
 		service = null;
 		if(optionalURL !="")
 		{
-				service= new NaturalLanguageUnderstanding("2018-03-16");
+				service= new NaturalLanguageUnderstanding(versionDate);
 				service.setApiKey("");
 				service.setEndPoint(optionalURL);
 		}
 		else
 		{
-			service= new NaturalLanguageUnderstanding("2018-03-16", userName, password);
+			service= new NaturalLanguageUnderstanding(versionDate, userName, password);
 		}
 
 	}
@@ -40,7 +41,7 @@ public class SimpleNLUClient {
 			.apiKey(apikey)
 			.build();
 
-		service= new NaturalLanguageUnderstanding("2018-03-16", options);
+		service= new NaturalLanguageUnderstanding(versionDate, options);
 		service.setEndPoint(url);
 	}
 

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,3 +1,9 @@
-NATURAL_LANGUAGE_UNDERSTANDING_USERNAME = <add_nlu_username>
-NATURAL_LANGUAGE_UNDERSTANDING_PASSWORD = <add_nlu_password>
-WATSON_KNOWLEDGE_STUDIO_MODEL_ID = <add_model_id>
+# Watson Natural Language Understanding
+NATURAL_LANGUAGE_UNDERSTANDING_URL=https://gateway.watsonplatform.net/natural-language-understanding/api
+## Un-comment and use either username+password or IAM apikey.
+NATURAL_LANGUAGE_UNDERSTANDING_IAM_APIKEY=<add_nlu_iam_apikey>
+#NATURAL_LANGUAGE_UNDERSTANDING_USERNAME=<add_nlu_username>
+#NATURAL_LANGUAGE_UNDERSTANDING_PASSWORD=<add_nlu_password>
+
+# Watson Knowledge Studio Model ID
+WATSON_KNOWLEDGE_STUDIO_MODEL_ID=<add_model_id>

--- a/src/main/webapp/META-INF/package.json
+++ b/src/main/webapp/META-INF/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "repository": {
      "type": "git",
-     "url": "https://github.com/ragudiko/wks-nlu-sms-analysis.git"
+     "url": "https://github.com/IBM/sms-analysis-with-wks.git"
   }
 }


### PR DESCRIPTION
This has been tested both locally and deployed to IBM Cloud.

- uses latest version of watson-developer-cloud
- added IAM_APIKEY to config.properties
- NLU created with either apikey or uname/pwd
- add NOTE to readme about navigation changes in WKS
- changed random-route to false in manifest.yml to reduce app name length
- cleaned up wrong repo references in pom file